### PR TITLE
skip support.docker.com

### DIFF
--- a/linkcheck.go
+++ b/linkcheck.go
@@ -46,6 +46,7 @@ var skipUrls = map[string]int{
 	"https://www.reddit.com/r/docker":                                   1,
 	"https://godoc.org/golang.org/x/crypto/ssh":                         1,
 	"https://letsencrypt.org/how-it-works/":                             1,
+	"https://support.docker.com":                                        1,
 }
 
 func crawl(chWork chan NewUrl, ch chan NewUrl, chFinished chan UrlResponse) {


### PR DESCRIPTION
the linkchecker didn't like the redirect it seems;

```
13:08:17 ERROR: (406) 2 links to (https://support.docker.com)
13:08:17             link https://support.docker.com on page engine/security/trust/trust_key_mng.md
13:08:17             link https://support.docker.com on page engine/security/trust/content_trust.md
```

ping @SvenDowideit @joaofnfernandes 
